### PR TITLE
Integração do envio de e-mail na recuperação de senha

### DIFF
--- a/src/app/pages/recuperacao-de-senha/recuperacao-de-senha.component.html
+++ b/src/app/pages/recuperacao-de-senha/recuperacao-de-senha.component.html
@@ -2,27 +2,26 @@
   <div class="grid justify-items-center w-full my-11 lg:my-40 xl:my-52">
     <header class="grid justify-items-center gap-2 mb-4 pt-5 lg:gap-3 lg:mb-6 lg:pt-10">
       <h1 class="text-xl font-extrabold drop-shadow-lg md:text-3xl">Informe seu e-mail</h1>
-      <p class="text-placeholder_color text-center font-bold text-xs px-5 md:text-base">Enviaremos as instruções para que você possa trocar sua senha.</p>
+      <p class="text-placeholder_color text-center font-bold text-xs px-5 md:text-base">
+        Enviaremos as instruções para que você possa trocar sua senha.
+      </p>
     </header>
 
-    <form action="" class="grid gap-3 md:gap-5 w-full px-4 sm:px-40 md:px-32 lg:px-20 xl:px-36 mb-2">
-      <app-input
-        for="email"
-        label="E-mail"
+    <form (submit)="enviarEmail(); $event.preventDefault()" class="grid gap-3 md:gap-5 w-full px-4 sm:px-40 md:px-32 lg:px-20 xl:px-36 mb-2">
+      <input
+        [(ngModel)]="email"
+        name="email"
         id="email"
         type="email"
         placeholder="E-mail *"
-        aria-placeholder="digite seu e-mail"
-        name="email"
-        [required]="true"
-      ></app-input>
+        required
+        class="w-full border border-gray-300 rounded p-2 focus:outline-none focus:ring-2 focus:ring-primary"
+      />
 
       <div class="flex flex-col w-full items-center gap-2 lg:gap-3 pb-3">
-        <app-button-primary title="Enviar"></app-button-primary>
-
+        <app-button-primary title="Enviar" type="submit"></app-button-primary>
         <app-button-secondary title="Voltar" routerLink=""></app-button-secondary>
       </div>
     </form>
   </div>
 </app-template-telas-iniciais>
-

--- a/src/app/pages/recuperacao-de-senha/recuperacao-de-senha.component.ts
+++ b/src/app/pages/recuperacao-de-senha/recuperacao-de-senha.component.ts
@@ -1,10 +1,44 @@
 import { Component } from '@angular/core';
+import { EmailService } from '../../shared/service/EmailService';
+import Swal from 'sweetalert2'; 
 
 @Component({
   selector: 'app-recuperacao-de-senha',
   templateUrl: './recuperacao-de-senha.component.html',
-  styleUrl: './recuperacao-de-senha.component.scss'
+  styleUrls: ['./recuperacao-de-senha.component.scss']
 })
 export class RecuperacaoDeSenhaComponent {
+  email: string = '';
 
+  constructor(private emailService: EmailService) {}
+
+  enviarEmail() {
+    if (!this.email) {
+      Swal.fire({
+        icon: 'error',
+        title: 'Erro!',
+        text: 'Por favor, informe um e-mail válido.',
+      });
+      return;
+    }
+
+    this.emailService.enviarEmailRecuperacao(this.email).subscribe({
+      next: () => {
+        Swal.fire({
+          icon: 'success',
+          title: 'E-mail enviado com sucesso!',
+          text: 'Verifique sua caixa de entrada.',
+        });
+        this.email = '';
+      },
+      error: (err) => {
+        Swal.fire({
+          icon: 'error',
+          title: 'Erro!',
+          text: 'Erro ao enviar o e-mail. Tente novamente mais tarde.',
+        });
+        console.error('Erro ao enviar e-mail:', err);
+      }
+    });
+  }
 }

--- a/src/app/shared/service/emailService.ts
+++ b/src/app/shared/service/emailService.ts
@@ -1,0 +1,17 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EmailService {
+  private apiUrl = 'http://localhost:8080/api/password/reset';
+
+  constructor(private http: HttpClient) {}
+
+  enviarEmailRecuperacao(email: string) {
+    return this.http.post(this.apiUrl, { email }, {
+      responseType: 'text'
+    });
+  }
+}


### PR DESCRIPTION
Conectei o front com a API de envio de e-mail feita em Spring Boot. Ao enviar o formulário de contato, os dados são mandados pro backend e o usuário recebe o retorno (sucesso/erro).

Feito:

Chamada pro endpoint de e-mail

Feedback visual de status

Ajustes no formulário

Como testar:
Preenche e envia o formulário com um e-mail já cadastrado. Verifica no o e-mail e teste a nova senha.